### PR TITLE
Remove invalid filters which breaks the website

### DIFF
--- a/KoreanList/koreanlist_specific_hide.txt
+++ b/KoreanList/koreanlist_specific_hide.txt
@@ -443,5 +443,3 @@ dak.gg##.pa_top4
 dak.gg##div[id^="google_ads_iframe"]
 gukjenews.com##.banner_box
 namu.wiki###D7bCic0bB
-ygosu.com###right_nav
-ygosu.com##.left_ban


### PR DESCRIPTION
FollowPR from #428 

Thank you for the response!

<img width="721" alt="image" src="https://user-images.githubusercontent.com/99162643/153528851-e9869f56-4838-4ffd-8179-5b13ffce3f42.png">

<img width="1027" alt="image" src="https://user-images.githubusercontent.com/99162643/153528926-f64b9eff-d102-4940-9073-1f395a8ed470.png">

But it seems to get same alert message, even if only one of the remaining filters applied.
Can I ask you to check this and fix the filters?