### PR TITLE
A:`tvreport.co.kr`

### DIFF
--- a/KoreanList/koreanlist_specific_hide.txt
+++ b/KoreanList/koreanlist_specific_hide.txt
@@ -1,3 +1,4 @@
+tvreport.co.kr##.tvreport-gsm-video-ad
 humoruniv.com##a[href^="https://shopping-m.ggeal.com"]
 veritas.kr##.s-bn
 mimint.co.kr##.ad


### PR DESCRIPTION
Hi could you please review and add this filter to the list, there is a left other blank advertisement video space left on this domain for example you can see on this [article page](https://tvreport.co.kr/star/article/737888/):
![image](https://github.com/easylist/KoreanList/assets/33602691/42cb5b1f-7f25-4d44-915e-991562f8b017)
Thank you